### PR TITLE
Dev/v0.6.0

### DIFF
--- a/any_auth/types/oauth2.py
+++ b/any_auth/types/oauth2.py
@@ -16,11 +16,16 @@ import pydantic
 
 # Define standard OAuth2 grant types
 class GrantType(str, enum.Enum):
+    """
+    OAuth 2.0 grant types.
+    """
+
     AUTHORIZATION_CODE = "authorization_code"
     IMPLICIT = "implicit"
     PASSWORD = "password"
     CLIENT_CREDENTIALS = "client_credentials"
     REFRESH_TOKEN = "refresh_token"
+    GOOGLE = "google"  # Add support for Google OAuth grant
 
 
 # Define standard OAuth2 response types
@@ -88,21 +93,18 @@ class TokenRequest(pydantic.BaseModel):
     """
 
     grant_type: GrantType
-
-    # For authorization_code grant
+    client_id: str | None = None
+    client_secret: str | None = None
+    redirect_uri: str | None = None
     code: str | None = None
-    redirect_uri: pydantic.HttpUrl | None = None
-    code_verifier: str | None = None
-
-    # For password grant
+    refresh_token: str | None = None
     username: str | None = None
     password: str | None = None
-
-    # For refresh_token grant
-    refresh_token: str | None = None
-
-    # Common parameter
     scope: str | None = None
+    code_verifier: str | None = None
+    # Google OAuth specific fields
+    google_token: str | None = None
+    google_id: str | None = None
 
 
 class TokenResponse(pydantic.BaseModel):

--- a/any_auth/types/oauth_client.py
+++ b/any_auth/types/oauth_client.py
@@ -22,6 +22,7 @@ class OAuthClientCreate(pydantic.BaseModel):
             "password",
             "client_credentials",
             "refresh_token",
+            "google",
         ]
     ] = pydantic.Field(default_factory=lambda: ["authorization_code", "refresh_token"])
     allowed_response_types: typing.List[typing.Literal["code", "token", "id_token"]] = (
@@ -89,6 +90,7 @@ class OAuthClient(pydantic.BaseModel):
             "password",
             "client_credentials",
             "refresh_token",
+            "google",
         ]
     ] = pydantic.Field(default_factory=lambda: ["authorization_code", "refresh_token"])
     allowed_response_types: typing.List[typing.Literal["code", "token", "id_token"]] = (

--- a/any_auth/utils/google_auth.py
+++ b/any_auth/utils/google_auth.py
@@ -1,0 +1,46 @@
+"""
+Google OAuth2 verification utilities.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Google's token info endpoint
+GOOGLE_TOKEN_INFO_URL = "https://oauth2.googleapis.com/tokeninfo"
+
+
+async def verify_google_token(token: str) -> Optional[Dict[str, Any]]:
+    """
+    Verify a Google OAuth token by calling Google's token verification endpoint.
+
+    Args:
+        token: The Google access token or ID token to verify
+
+    Returns:
+        Dict with user information if valid, None if invalid
+    """
+    try:
+        # Try first as an ID token
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{GOOGLE_TOKEN_INFO_URL}?id_token={token}")
+
+        if response.status_code == 200:
+            return response.json()
+
+        # If that fails, try as an access token
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{GOOGLE_TOKEN_INFO_URL}?access_token={token}")
+
+        if response.status_code == 200:
+            return response.json()
+
+        logger.warning(f"Invalid Google token. Status: {response.status_code}")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error verifying Google token: {e}")
+        return None

--- a/scripts/get_started/ensure_app_application_client.py
+++ b/scripts/get_started/ensure_app_application_client.py
@@ -38,7 +38,12 @@ def create_server_application_client(backend_client: BackendClient) -> OAuthClie
                 "http://localhost:3000/callback",
                 "http://localhost:5173/callback",
             ],
-            "allowed_grant_types": ["password", "refresh_token", "authorization_code"],
+            "allowed_grant_types": [
+                "password",
+                "refresh_token",
+                "authorization_code",
+                "google",
+            ],
             "allowed_scopes": ["openid", "profile", "email", "offline_access"],
             "client_type": "confidential",
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -940,7 +940,12 @@ def deps_oauth_clients(
                 "http://localhost:5173/callback",
             ],
             "client_type": "confidential",
-            "allowed_grant_types": ["password", "refresh_token", "authorization_code"],
+            "allowed_grant_types": [
+                "password",
+                "refresh_token",
+                "authorization_code",
+                "google",
+            ],
             "allowed_response_types": ["code", "token"],
             "allowed_scopes": ["openid", "email", "profile"],
         }


### PR DESCRIPTION
## ENH: Add Google OAuth Grant Support to OAuth2 API

This PR introduces support for authenticating users via Google OAuth in the OAuth2 API, along with related improvements and refactoring.

### Highlights
- **Google Grant Type**: Adds a new `google` grant type to the OAuth2 token endpoint, allowing users to authenticate using a Google token and Google ID.
- **Token Verification**: Implements `verify_google_token` utility to validate Google tokens using Google's token info endpoint.
- **User Linking**: On successful Google authentication, the user's account is linked by email and the Google ID is stored in user metadata.
- **Client Configuration**: Updates OAuth client models and test fixtures to include `"google"` in allowed grant types.
- **Logging**: Improves logging throughout the OAuth2 flow for better traceability and debugging.
- **User Existence Check**: Refactors `/users/check` endpoint to allow OAuth clients to check for existing users by email or username, removing the previous version that required user authentication.

### Summary of Changes

- `any_auth/api/oauth2.py`
  - Adds handling for the `google` grant type in the token endpoint.
  - Implements `GrantHandler.handle_google_grant` for Google OAuth authentication and user linking.
  - Adds detailed logging for grant handling and error cases.

- `any_auth/types/oauth2.py`
  - Adds `GOOGLE` to `GrantType` enum.
  - Updates `TokenRequest` to include `google_token` and `google_id` fields.

- `any_auth/types/oauth_client.py`
  - Adds `"google"` to default allowed grant types for OAuth clients.

- `any_auth/utils/google_auth.py`
  - New utility for verifying Google tokens via Google's public API.

- `any_auth/api/v1/users/route.py`
  - Refactors `/users/check` endpoint to allow OAuth client-based checks for user existence by email or username.

- `scripts/get_started/ensure_app_application_client.py`
  - Updates default OAuth client creation to include `"google"` in allowed grant types.

- `tests/conftest.py`
  - Updates test OAuth client fixtures to include `"google"` in allowed grant types.

### Backward Compatibility

- Existing grant types and endpoints remain unchanged.
- The `/users/check` endpoint is now accessible to OAuth clients, not just authenticated users.

### Notes

- This PR does not implement user creation via Google OAuth; it only links existing users by email.
- Proper error handling and logging are included for easier debugging and monitoring.

---

**Closes**: # (reference issue if applicable)
